### PR TITLE
Add Telegram session model

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -79,7 +79,7 @@
 from logging.config import fileConfig
 from sqlalchemy import engine_from_config, pool
 from alembic import context
-from src.infrastructure.database.models.user import Base
+from src.infrastructure.database.models import Base
 from src.core.config import settings
 
 config = context.config

--- a/src/infrastructure/database/models/__init__.py
+++ b/src/infrastructure/database/models/__init__.py
@@ -1,0 +1,8 @@
+from .user import Base, UserModel
+from .telegram_session import TelegramSessionModel
+
+__all__ = [
+    "Base",
+    "UserModel",
+    "TelegramSessionModel",
+]

--- a/src/infrastructure/database/models/telegram_session.py
+++ b/src/infrastructure/database/models/telegram_session.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from datetime import datetime
+
+from .user import Base
+
+class TelegramSessionModel(Base):
+    __tablename__ = "telegram_sessions"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    session_name = Column(String, unique=True, nullable=False)
+    api_id = Column(Integer, nullable=False)
+    api_hash = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## Summary
- add `TelegramSessionModel` SQLAlchemy table
- expose models via `models/__init__.py`
- reference new models in Alembic env
- generate and apply migration in SQLite (users & telegram_sessions)

## Testing
- `alembic revision --autogenerate -m "add telegram sessions table"`
- `alembic upgrade head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869546096308325afd18457cd0b03c0