### PR TITLE
Implement Telegram sessions endpoint

### DIFF
--- a/src/core/dependencies.py
+++ b/src/core/dependencies.py
@@ -5,9 +5,13 @@
 
 from fastapi import Request, HTTPException, Depends
 from src.infrastructure.database.repositories.user_repository import SQLAlchemyUserRepository
+from src.infrastructure.database.repositories.telegram_session_repository import (
+    SQLAlchemyTelegramSessionRepository,
+)
 from src.infrastructure.database.session import get_db_session
 from passlib.context import CryptContext
 from src.domain.services.user_service import UserService
+from src.domain.services.telegram_session_service import TelegramSessionService
 from authx import TokenPayload
 from src.core.auth import authx  # Импортируем уже настроенный AuthX
 
@@ -22,6 +26,15 @@ def get_user_service(session=Depends(get_db_session)) -> UserService:
         SQLAlchemyUserRepository(session),
         authx=authx,
         pwd_context=pwd_context
+    )
+
+
+def get_telegram_session_service(
+    session=Depends(get_db_session),
+) -> TelegramSessionService:
+    """Создаем сервис телеграм-сессий."""
+    return TelegramSessionService(
+        SQLAlchemyTelegramSessionRepository(session)
     )
 
 async def get_current_user(

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.core.config import settings
 from src.core.dependencies import get_current_user
 from src.presentation.api.v1.auth import router as auth_router
+from src.presentation.api.v1.telegram import router as telegram_router
 from src.core.auth import authx
 
 # Создаем приложение
@@ -36,6 +37,7 @@ templates = Jinja2Templates(directory="templates")
 
 # Подключаем роутеры
 app.include_router(auth_router)
+app.include_router(telegram_router)
 
 @app.get("/")
 async def index(request: Request):

--- a/src/presentation/api/v1/telegram.py
+++ b/src/presentation/api/v1/telegram.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from src.core.dependencies import (
+    get_current_user,
+    get_telegram_session_service,
+)
+from src.domain.services.telegram_session_service import TelegramSessionService
+from src.presentation.schemas.telegram_session import TelegramSessionCreate
+
+router = APIRouter(prefix="/api/v1/telegram", tags=["telegram"])
+
+
+@router.post("/telegram/sessions")
+async def create_telegram_session(
+    session_data: TelegramSessionCreate,
+    current_user=Depends(get_current_user),
+    service: TelegramSessionService = Depends(get_telegram_session_service),
+):
+    """Create and store a new Telegram session."""
+    try:
+        session = await service.add_session(
+            user_id=current_user["id"],
+            session_name=session_data.session_name,
+            api_id=session_data.api_id,
+            api_hash=session_data.api_hash,
+            phone=session_data.phone,
+            code=session_data.otp,
+            password=session_data.password,
+        )
+        return {
+            "id": session.id,
+            "session_name": session.session_name,
+            "api_id": session.api_id,
+            "api_hash": session.api_hash,
+            "created_at": session.created_at,
+        }
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/src/presentation/schemas/telegram_session.py
+++ b/src/presentation/schemas/telegram_session.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+class TelegramSessionCreate(BaseModel):
+    session_name: str
+    api_id: int
+    api_hash: str
+    phone: str
+    otp: str = Field(..., description="One-time code sent to Telegram")
+    password: Optional[str] = None


### PR DESCRIPTION
## Summary
- add Telegram session creation schema and router
- create Telegram session service dependency
- register new Telegram router in main app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869705375f48325bcaebca380a1fe32