### PR TITLE
Add dedicated Telegram session page

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -47,6 +47,11 @@ async def index(request: Request):
 async def dashboard(request: Request, user=Depends(get_current_user)):
     return templates.TemplateResponse("dashboard.html", {"request": request, "user": user})
 
+
+@app.get("/telegram/add")
+async def add_telegram_page(request: Request, user=Depends(get_current_user)):
+    return templates.TemplateResponse("add_telegram.html", {"request": request, "user": user})
+
 @app.get("/health")
 async def health_check():
     return {"status": "healthy"}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,9 +13,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const emailInput = document.getElementById("email");
     const passwordInput = document.getElementById("password");
 
-    const tgModal = document.getElementById('telegram-modal');
-    const addTgBtn = document.getElementById('add-telegram-btn');
-    const tgCloseBtn = tgModal ? tgModal.querySelector('.close-btn') : null;
     const tgForm = document.getElementById('telegram-form');
 
     let isLogin = true;
@@ -118,13 +115,6 @@ document.addEventListener("DOMContentLoaded", () => {
         };
     }
 
-    if (addTgBtn) {
-        addTgBtn.onclick = () => showModal(tgModal);
-    }
-
-    if (tgCloseBtn) {
-        tgCloseBtn.onclick = () => hideModal(tgModal);
-    }
 
     if (tgForm) {
         tgForm.onsubmit = async (e) => {
@@ -150,7 +140,6 @@ document.addEventListener("DOMContentLoaded", () => {
                 if (response.ok) {
                     alert('Сессия создана');
                     tgForm.reset();
-                    hideModal(tgModal);
                 } else {
                     const err = await response.json();
                     alert(err.detail || 'Ошибка');

--- a/templates/add_telegram.html
+++ b/templates/add_telegram.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Добавить Telegram сессию</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <div class="dashboard-container">
+        <header class="dashboard-header">
+            <h1>Dating Portal</h1>
+            <div class="dashboard-actions">
+                <a href="/dashboard"><button>Назад</button></a>
+            </div>
+        </header>
+        <main class="dashboard-content">
+            <div class="form-container">
+                <h2>Добавить Telegram сессию</h2>
+                <form id="telegram-form">
+                    <div class="input-wrapper">
+                        <input type="text" id="session-name" placeholder="Session name" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="number" id="api-id" placeholder="API ID" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="text" id="api-hash" placeholder="API Hash" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="text" id="phone" placeholder="Phone" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="text" id="otp" placeholder="OTP" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="password" id="session-password" placeholder="Password (если есть)">
+                    </div>
+                    <button type="submit" id="submit-telegram">Сохранить</button>
+                </form>
+            </div>
+        </main>
+    </div>
+    <script src="/static/js/main.js" defer></script>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -11,7 +11,7 @@
             <h1>Dating Portal</h1>
             <div class="dashboard-actions">
                 <button id="start-btn">Начать работу</button>
-                <button id="add-telegram-btn">Добавить Telegram-аккаунт</button>
+                <a href="/telegram/add"><button>Добавить Telegram-аккаунт</button></a>
                 <a href="/faq"><button>Инструкция</button></a>
             </div>
         </header>
@@ -25,33 +25,6 @@
         </main>
     </div>
 
-    <div id="telegram-modal" class="modal hidden">
-        <div class="form-container">
-            <span class="close-btn">&times;</span>
-            <h2>Добавить Telegram сессию</h2>
-            <form id="telegram-form">
-                <div class="input-wrapper">
-                    <input type="text" id="session-name" placeholder="Session name" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="number" id="api-id" placeholder="API ID" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="text" id="api-hash" placeholder="API Hash" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="text" id="phone" placeholder="Phone" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="text" id="otp" placeholder="OTP" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="password" id="session-password" placeholder="Password (если есть)">
-                </div>
-                <button type="submit" id="submit-telegram">Сохранить</button>
-            </form>
-        </div>
-    </div>
 
     <script src="/static/js/main.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- create a new `add_telegram.html` page with a form to add Telegram sessions
- link to the new page from dashboard
- remove modal from dashboard and simplify JS handling
- expose `/telegram/add` route

## Testing
- `python -m compileall -q src templates static`
- `pip install alembic`
- `alembic upgrade head` *(fails: `ModuleNotFoundError: No module named 'pydantic_settings'`)*
- `uvicorn src.main:app --reload` *(fails: `ModuleNotFoundError: No module named 'dotenv'`)*

------
https://chatgpt.com/codex/tasks/task_e_68694fbb25248325a65e177f1b0b49af