### PR TITLE
Add dedicated Telegram session page

### DIFF
--- a/src/domain/services/telegram_session_service.py
+++ b/src/domain/services/telegram_session_service.py
@@ -9,6 +9,8 @@ from src.domain.entities.telegram_session import TelegramSession
 class TelegramSessionService:
     def __init__(self, repository):
         self.repo = repository
+        # Temporary store for ongoing authorizations
+        self._pending: dict[str, dict] = {}
 
     async def add_session(
         self,
@@ -16,32 +18,74 @@ class TelegramSessionService:
         session_name: str,
         api_id: int,
         api_hash: str,
-        phone: str,
-        code: str,
-        password: str | None = None,
-    ) -> TelegramSession:
-        """Create a Telegram session file and persist its metadata."""
+    ) -> None:
+        """Start session creation by storing initial parameters."""
+
+        self._pending[session_name] = {
+            "user_id": user_id,
+            "api_id": api_id,
+            "api_hash": api_hash,
+        }
+
+    async def provide_phone(self, session_name: str, phone: str) -> None:
+        """Send authentication code to the given phone number."""
+
+        data = self._pending.get(session_name)
+        if not data:
+            raise ValueError("Session not initialized")
 
         client = Client(
             session_name,
-            api_id=api_id,
-            api_hash=api_hash,
+            api_id=data["api_id"],
+            api_hash=data["api_hash"],
             workdir=settings.TG_SESSION_DIR,
         )
 
         await client.connect()
-        await client.send_code(phone)
-        await client.sign_in(phone, code, password=password)
+        sent_code = await client.send_code(phone)
+        await client.disconnect()
+
+        data["phone"] = phone
+        data["phone_code_hash"] = sent_code.phone_code_hash
+
+    async def confirm_code(
+        self,
+        session_name: str,
+        code: str,
+        password: str | None = None,
+    ) -> TelegramSession:
+        """Finalize authorization with the received code and optional password."""
+
+        data = self._pending.get(session_name)
+        if not data:
+            raise ValueError("Session not initialized")
+
+        client = Client(
+            session_name,
+            api_id=data["api_id"],
+            api_hash=data["api_hash"],
+            workdir=settings.TG_SESSION_DIR,
+        )
+
+        await client.connect()
+        await client.sign_in(
+            phone_number=data["phone"],
+            phone_code_hash=data["phone_code_hash"],
+            phone_code=code,
+            password=password,
+        )
         await client.disconnect()
 
         session = TelegramSession(
             id=0,
-            user_id=user_id,
+            user_id=data["user_id"],
             session_name=session_name,
-            api_id=api_id,
-            api_hash=api_hash,
+            api_id=data["api_id"],
+            api_hash=data["api_hash"],
             created_at=datetime.utcnow(),
         )
 
-        return await self.repo.create(session)
+        result = await self.repo.create(session)
+        self._pending.pop(session_name, None)
+        return result
 

--- a/src/main.py
+++ b/src/main.py
@@ -47,6 +47,11 @@ async def index(request: Request):
 async def dashboard(request: Request, user=Depends(get_current_user)):
     return templates.TemplateResponse("dashboard.html", {"request": request, "user": user})
 
+
+@app.get("/telegram/add")
+async def add_telegram_page(request: Request, user=Depends(get_current_user)):
+    return templates.TemplateResponse("add_telegram.html", {"request": request, "user": user})
+
 @app.get("/health")
 async def health_check():
     return {"status": "healthy"}

--- a/src/presentation/api/v1/telegram.py
+++ b/src/presentation/api/v1/telegram.py
@@ -5,27 +5,60 @@ from src.core.dependencies import (
     get_telegram_session_service,
 )
 from src.domain.services.telegram_session_service import TelegramSessionService
-from src.presentation.schemas.telegram_session import TelegramSessionCreate
+from src.presentation.schemas.telegram_session import (
+    TelegramSessionStart,
+    TelegramSessionPhone,
+    TelegramSessionConfirm,
+)
 
 router = APIRouter(prefix="/api/v1/telegram", tags=["telegram"])
 
 
-@router.post("/telegram/sessions")
-async def create_telegram_session(
-    session_data: TelegramSessionCreate,
+@router.post("/telegram/sessions/start")
+async def start_session(
+    data: TelegramSessionStart,
     current_user=Depends(get_current_user),
     service: TelegramSessionService = Depends(get_telegram_session_service),
 ):
-    """Create and store a new Telegram session."""
+    """Initialize session creation and request phone."""
     try:
-        session = await service.add_session(
+        await service.add_session(
             user_id=current_user["id"],
-            session_name=session_data.session_name,
-            api_id=session_data.api_id,
-            api_hash=session_data.api_hash,
-            phone=session_data.phone,
-            code=session_data.otp,
-            password=session_data.password,
+            session_name=data.session_name,
+            api_id=data.api_id,
+            api_hash=data.api_hash,
+        )
+        return {"detail": "phone required"}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/telegram/sessions/phone")
+async def send_phone(
+    data: TelegramSessionPhone,
+    current_user=Depends(get_current_user),
+    service: TelegramSessionService = Depends(get_telegram_session_service),
+):
+    """Send phone number and request OTP."""
+    try:
+        await service.provide_phone(data.session_name, data.phone)
+        return {"detail": "otp required"}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/telegram/sessions/confirm")
+async def confirm_code(
+    data: TelegramSessionConfirm,
+    current_user=Depends(get_current_user),
+    service: TelegramSessionService = Depends(get_telegram_session_service),
+):
+    """Finalize authorization with OTP and optional password."""
+    try:
+        session = await service.confirm_code(
+            session_name=data.session_name,
+            code=data.otp,
+            password=data.password,
         )
         return {
             "id": session.id,

--- a/src/presentation/schemas/telegram_session.py
+++ b/src/presentation/schemas/telegram_session.py
@@ -1,10 +1,19 @@
 from pydantic import BaseModel, Field
 from typing import Optional
 
-class TelegramSessionCreate(BaseModel):
+
+class TelegramSessionStart(BaseModel):
     session_name: str
     api_id: int
     api_hash: str
+
+
+class TelegramSessionPhone(BaseModel):
+    session_name: str
     phone: str
+
+
+class TelegramSessionConfirm(BaseModel):
+    session_name: str
     otp: str = Field(..., description="One-time code sent to Telegram")
     password: Optional[str] = None

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,9 +13,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const emailInput = document.getElementById("email");
     const passwordInput = document.getElementById("password");
 
-    const tgModal = document.getElementById('telegram-modal');
-    const addTgBtn = document.getElementById('add-telegram-btn');
-    const tgCloseBtn = tgModal ? tgModal.querySelector('.close-btn') : null;
     const tgForm = document.getElementById('telegram-form');
 
     let isLogin = true;
@@ -118,39 +115,53 @@ document.addEventListener("DOMContentLoaded", () => {
         };
     }
 
-    if (addTgBtn) {
-        addTgBtn.onclick = () => showModal(tgModal);
-    }
-
-    if (tgCloseBtn) {
-        tgCloseBtn.onclick = () => hideModal(tgModal);
-    }
 
     if (tgForm) {
         tgForm.onsubmit = async (e) => {
             e.preventDefault();
 
-            const payload = {
-                session_name: document.getElementById('session-name').value.trim(),
-                api_id: parseInt(document.getElementById('api-id').value.trim(), 10),
-                api_hash: document.getElementById('api-hash').value.trim(),
-                phone: document.getElementById('phone').value.trim(),
-                otp: document.getElementById('otp').value.trim(),
-                password: document.getElementById('session-password').value.trim() || null,
-            };
+            const sessionName = document.getElementById('session-name').value.trim();
+            const apiId = parseInt(document.getElementById('api-id').value.trim(), 10);
+            const apiHash = document.getElementById('api-hash').value.trim();
+            const phone = document.getElementById('phone').value.trim();
+            const otp = document.getElementById('otp').value.trim();
+            const password = document.getElementById('session-password').value.trim() || null;
+
+            const base = '/api/v1/telegram/sessions';
 
             try {
-                const response = await fetch('/api/v1/telegram/sessions', {
+                let response = await fetch(`${base}/start`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     credentials: 'include',
-                    body: JSON.stringify(payload),
+                    body: JSON.stringify({ session_name: sessionName, api_id: apiId, api_hash: apiHash })
+                });
+                if (!response.ok) {
+                    const err = await response.json();
+                    throw new Error(err.detail || 'Ошибка инициализации');
+                }
+
+                response = await fetch(`${base}/phone`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({ session_name: sessionName, phone })
+                });
+                if (!response.ok) {
+                    const err = await response.json();
+                    throw new Error(err.detail || 'Ошибка отправки телефона');
+                }
+
+                response = await fetch(`${base}/confirm`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({ session_name: sessionName, otp, password })
                 });
 
                 if (response.ok) {
                     alert('Сессия создана');
                     tgForm.reset();
-                    hideModal(tgModal);
                 } else {
                     const err = await response.json();
                     alert(err.detail || 'Ошибка');

--- a/templates/add_telegram.html
+++ b/templates/add_telegram.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Добавить Telegram сессию</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <div class="dashboard-container">
+        <header class="dashboard-header">
+            <h1>Dating Portal</h1>
+            <div class="dashboard-actions">
+                <a href="/dashboard"><button>Назад</button></a>
+            </div>
+        </header>
+        <main class="dashboard-content">
+            <div class="form-container">
+                <h2>Добавить Telegram сессию</h2>
+                <form id="telegram-form">
+                    <div class="input-wrapper">
+                        <input type="text" id="session-name" placeholder="Session name" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="number" id="api-id" placeholder="API ID" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="text" id="api-hash" placeholder="API Hash" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="text" id="phone" placeholder="Phone" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="text" id="otp" placeholder="OTP" required>
+                    </div>
+                    <div class="input-wrapper">
+                        <input type="password" id="session-password" placeholder="Password (если есть)">
+                    </div>
+                    <button type="submit" id="submit-telegram">Сохранить</button>
+                </form>
+            </div>
+        </main>
+    </div>
+    <script src="/static/js/main.js" defer></script>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -11,7 +11,7 @@
             <h1>Dating Portal</h1>
             <div class="dashboard-actions">
                 <button id="start-btn">Начать работу</button>
-                <button id="add-telegram-btn">Добавить Telegram-аккаунт</button>
+                <a href="/telegram/add"><button>Добавить Telegram-аккаунт</button></a>
                 <a href="/faq"><button>Инструкция</button></a>
             </div>
         </header>
@@ -25,33 +25,6 @@
         </main>
     </div>
 
-    <div id="telegram-modal" class="modal hidden">
-        <div class="form-container">
-            <span class="close-btn">&times;</span>
-            <h2>Добавить Telegram сессию</h2>
-            <form id="telegram-form">
-                <div class="input-wrapper">
-                    <input type="text" id="session-name" placeholder="Session name" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="number" id="api-id" placeholder="API ID" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="text" id="api-hash" placeholder="API Hash" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="text" id="phone" placeholder="Phone" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="text" id="otp" placeholder="OTP" required>
-                </div>
-                <div class="input-wrapper">
-                    <input type="password" id="session-password" placeholder="Password (если есть)">
-                </div>
-                <button type="submit" id="submit-telegram">Сохранить</button>
-            </form>
-        </div>
-    </div>
 
     <script src="/static/js/main.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- create a new `add_telegram.html` page with a form to add Telegram sessions
- link to the new page from dashboard
- remove modal from dashboard and simplify JS handling
- expose `/telegram/add` route
- refactor backend flow so Telegram session setup happens in three steps

## Testing
- `python -m compileall -q src templates static`
- `pip install alembic`
- `alembic upgrade head` *(fails: `ModuleNotFoundError: No module named 'pydantic_settings'`)*
- `uvicorn src.main:app --reload` *(fails: `ModuleNotFoundError: No module named 'dotenv'`)*

------
https://chatgpt.com/codex/tasks/task_e_68694fbb25248325a65e177f1b0b49af